### PR TITLE
Allow workflows to write

### DIFF
--- a/otterdog/eclipse-lsp4j.jsonnet
+++ b/otterdog/eclipse-lsp4j.jsonnet
@@ -7,6 +7,7 @@ orgs.newOrg('technology.lsp4j', 'eclipse-lsp4j') {
     web_commit_signoff_required: false,
     workflows+: {
       actions_can_approve_pull_request_reviews: false,
+      default_workflow_permissions: "write",
     },
   },
   webhooks+: [


### PR DESCRIPTION
This is so that the junit workflow can run successfully. This setting matches other orgs, such as platform and cdt.